### PR TITLE
No step fix

### DIFF
--- a/LTSpice_RawRead.py
+++ b/LTSpice_RawRead.py
@@ -140,7 +140,10 @@ class Axis(DataSet):
 
     def step_offset(self, step):
         if self.step_info == None:
-            return 0
+            if step > 0:
+                return len(self.data)
+            else:
+                return 0
         else:
             if step >= len(self.step_offsets):
                 return len(self.data)


### PR DESCRIPTION
Running a simulation without a .step parameter sweep causes Axis.get_wave to return an empty array. Updated Axis.step_offset to account for this use case. This fork includes Jacob's UTF-16-LE fix.