### PR TITLE
Update _load_step_information to accommodate temperature steps.

### DIFF
--- a/LTSpice_RawRead.py
+++ b/LTSpice_RawRead.py
@@ -452,7 +452,9 @@ class LTSpiceRawRead(object):
                 step_dict = {}
                 for tok in line[6:-1].split(' '):
                     key, value = tok.split('=')
-                    step_dict[key] = float(value)
+                    # Leave value as a string to accomodate temperature steps
+                    # Temperature steps have the form '.step temp=25°C'
+                    step_dict[key] = value
 
                 if self.steps is None:
                     self.steps = [step_dict]


### PR DESCRIPTION
In LTSpice XVII, temperature steps have the form '.step temp=25°C' and this causes an exception in _load_step_information when attempting to cast the value '25°C' to a float. I recommend leaving the value as a string.