### PR TITLE
Allow LTSpice installation in non default location

### DIFF
--- a/PyLTSpice/LTSpiceBatch.py
+++ b/PyLTSpice/LTSpiceBatch.py
@@ -107,7 +107,10 @@ END_LINE_TERM = '\n'
 logging.basicConfig(filename='LTSpiceBatch.log', level=logging.INFO)
 
 if sys.platform == "linux":
-    LTspice_exe = ["wine", os.path.expanduser("~") + "/.wine/drive_c/Program Files/LTC/LTspiceXVII/XVIIx64.exe"]
+    if not os.environ.get('LTSPICEFOLDER') == None:
+        LTspice_exe = ["wine", os.environ['LTSPICEFOLDER'] + "/XVIIx64.exe"]
+    else:
+        LTspice_exe = ["wine", os.path.expanduser("~") + "/.wine/drive_c/Program Files/LTC/LTspiceXVII/XVIIx64.exe"]
     LTspice_arg = {'netlist': ['-netlist'], 'run': ['-b', '-Run']}
 elif sys.platform == "darwin":
     LTspice_exe = ['/Applications/LTspice.app/Contents/MacOS/LTspice']


### PR DESCRIPTION
Currently LTSpice needs to be installed in it's default location. This PR would allow a LTSPICEFOLDER global variable to be used to point to the LTSpice folder in order to allow an installation in a non default location.
Our use case is a cluster, where the home directory has a rather limited quota and commonly things should be installed elsewhere. 
The change should have no effect whatsoever on any existing code/use of the library.