### PR TITLE
Add support for pathlib file name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .vscode/
 __pycache__/
 PyLTSpice.egg-info
+venv
+.venv
+.python-version
+*.log

--- a/PyLTSpice/LTSpice_RawRead.py
+++ b/PyLTSpice/LTSpice_RawRead.py
@@ -188,6 +188,7 @@ from binascii import b2a_hex
 from collections import OrderedDict
 from struct import unpack
 from typing import Union, List, Tuple
+import pathlib
 from PyLTSpice.detect_encoding import detect_encoding
 
 try:
@@ -627,7 +628,7 @@ class LTSpiceRawRead(object):
     it will also try to read the corresponding LOG file so to retrieve the stepped data.
 
     :param raw_filename: The file containing the RAW data to be read
-    :type raw_filename: str
+    :type raw_filename: str | pahtlib.Path
     :param traces_to_read:
         A string or a list containing the list of traces to be read. If None is provided, only the header is read and
         all trace data is discarded. If a '*' wildcard is given or no parameter at all then all traces are read.
@@ -659,7 +660,8 @@ class LTSpiceRawRead(object):
 
     def __init__(self, raw_filename: str, traces_to_read: Union[str, List[str], Tuple[str], None] = '*', **kwargs):
         self.verbose = kwargs.get('verbose', True)
-        assert isinstance(raw_filename, str), "RAW filename is expected to be a string"
+        raw_filename = pathlib.Path(raw_filename)
+        # assert isinstance(raw_filename, str), "RAW filename is expected to be a string"
         if traces_to_read is not None:
             assert isinstance(traces_to_read, (str, list, tuple)), "traces_to_read must be a string, a list or None"
 
@@ -950,11 +952,11 @@ class LTSpiceRawRead(object):
         """
         return self.axis.get_len(step) 
 
-    def _load_step_information(self, filename):
+    def _load_step_information(self, filename:pathlib.Path):
         # Find the extension of the file
-        if not filename.endswith(".raw"):
+        if not filename.suffix == ".raw":
             raise LTSPiceReadException("Invalid Filename. The file should end with '.raw'")
-        logfile = filename[:-3] + 'log'
+        logfile = filename.with_suffix(".log")
         try:
             encoding = detect_encoding(logfile, "Circuit:")
             log = open(logfile, 'r', errors='replace', encoding=encoding)

--- a/PyLTSpice/LTSpice_RawRead.py
+++ b/PyLTSpice/LTSpice_RawRead.py
@@ -661,7 +661,6 @@ class LTSpiceRawRead(object):
     def __init__(self, raw_filename: str, traces_to_read: Union[str, List[str], Tuple[str], None] = '*', **kwargs):
         self.verbose = kwargs.get('verbose', True)
         raw_filename = pathlib.Path(raw_filename)
-        # assert isinstance(raw_filename, str), "RAW filename is expected to be a string"
         if traces_to_read is not None:
             assert isinstance(traces_to_read, (str, list, tuple)), "traces_to_read must be a string, a list or None"
 

--- a/PyLTSpice/LTSpice_RawWrite.py
+++ b/PyLTSpice/LTSpice_RawWrite.py
@@ -121,7 +121,7 @@ class LTSpiceRawWrite(object):
         :param filename: filename to where the RAW file is going to be written. Make sure that the extension of the file
         is .RAW.
 
-        :type filename: str
+        :type filename: str or pathlib.Path
         :return: Nothing
         :rtype: None
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ description = "A set of tools to Automate LTSpice simulations"
 readme = "README.md"
 license = { file="LICENSE" }
 requires-python = ">=3.7"
-requires = [
+dependencies = [
     "numpy",
 ]
 classifiers=[

--- a/tests/unittest/test_pyltspice.py
+++ b/tests/unittest/test_pyltspice.py
@@ -393,6 +393,13 @@ class test_pyltspice(unittest.TestCase):
                 self.assertAlmostEqual(angle(vout), angle(h), 5,
                                        f"Difference between theoretical value ans simulation at point {point}")
 
+    @unittest.skipIf(debugging is True, "While Debugging")
+    def test_pathlib(self):
+        """pathlib support"""
+        import pathlib
+        DIR = pathlib.Path("./tests")
+        raw_file = DIR / "AC - STEP_1.raw"
+        raw = LTSpiceRawRead(raw_file)
 
 # ------------------------------------------------------------------------------
 if __name__ == '__main__':


### PR DESCRIPTION
`pathlib` is the modern way of specifying file paths. The proposed change supports both string and pathlib.Path file names.

Additional changes:
- Py3.10, pip 22.2.2, setuptools 65.4.1 - complains that 'requires' is not allowed in pyproject.toml - [see setuptools docs](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html)
- remove `assert` - [see why](https://realpython.com/lessons/using-assert-keyword/#:~:text=You%20don%E2%80%99t%20want%20to%20use%20it%20in%20production,completely.%20So%2C%20that%E2%80%99s%20something%20that%E2%80%99s%20good%20to%20know.)
- Add a test case