### PR TITLE
Check for a space in front of parameters names

### DIFF
--- a/PyLTSpice/SpiceEditor.py
+++ b/PyLTSpice/SpiceEditor.py
@@ -93,7 +93,7 @@ REPLACE_REGXES = {
 }
 
 
-PARAM_REGEX = r"%s((\s*=\s*)|\s+)(?P<value>[\w*/\.+-/\*{}()]*)"
+PARAM_REGEX = r"(?<= )%s((\s*=\s*)|\s+)(?P<value>[\w*/\.+-/\*{}()]*)"
 SUBCKT_CLAUSE_FIND = r"^.SUBCKT\s+"
 
 # Code Optimization objects, avoiding repeated compilation of regular expressions


### PR DESCRIPTION
Hello Nuno! Hope you're doing well.

I discovered a small bug in the spice editor recently and wanted to suggest a fix. If you have multiple parameters that have an identical suffix (e.g. `c_a` and `r_c_a`) when the attempt is made to overwrite these the shorter parameter can match with the longer one instead of its real match. By adding a positive lookbehind for a space we can prevent this. In my very limited testing this did not cause any problems and did the trick, but I'm not sure if there are any potential side effects. 

Let me know if you see any issues with this fix.

Best,

Kyle