### PR TITLE
Fix bug with replace

### DIFF
--- a/PyLTSpice/SpiceEditor.py
+++ b/PyLTSpice/SpiceEditor.py
@@ -93,7 +93,7 @@ REPLACE_REGXES = {
 }
 
 
-PARAM_REGEX = r"(?<= )%s((\s*=\s*))(?P<value>[\w\*\/\.\+\-\/\*\{\}\(\)\t ]*)(?<!\s)($|\s+)(?!\s*=)"
+PARAM_REGEX = r"(?<= )(?P<replace>%s(\s*=\s*)(?P<value>[\w\*\/\.\+\-\/\*\{\}\(\)\t ]*))(?<!\s)($|\s+)(?!\s*=)"
 SUBCKT_CLAUSE_FIND = r"^.SUBCKT\s+"
 
 # Code Optimization objects, avoiding repeated compilation of regular expressions
@@ -564,7 +564,7 @@ class SpiceCircuit(object):
         regx = re.compile(PARAM_REGEX % param, re.IGNORECASE)
         param_line, match = self._get_line_matching('.PARAM', regx)
         if match:
-            start, stop = match.span()
+            start, stop = match.span(regx.groupindex['replace'])
             line = self.netlist[param_line]
             self.netlist[param_line] = line[:start] + "{}={}".format(param, value) + line[stop:]
         else:


### PR DESCRIPTION
Hi Nuno,

This PR fixes a bug I introduced with the new regex, I think we should be good now.

-Kyle


With new regex the space at the end is included in the match so when we replace it, we also delete the space which causes the new netlist to be invalid. This commit adds a new regex group `'replace'` that does not include the space at the end. We then use that group to get the span of the match. I also removed a set of redundant parathesis around the equal sign matching part of the pattern.