### PR TITLE
Fix PyLance typing error

### DIFF
--- a/PyLTSpice/raw/raw_read.py
+++ b/PyLTSpice/raw/raw_read.py
@@ -358,7 +358,7 @@ class RawRead(object):
         'Frequency Response Analysis',
     )
 
-    def __init__(self, raw_filename: str, traces_to_read: Union[str, List[str], Tuple[str], None] = '*', **kwargs):
+    def __init__(self, raw_filename: str, traces_to_read: Union[str, List[str], Tuple[str, ...], None] = '*', **kwargs):
         self.verbose = kwargs.get('verbose', True)
         raw_filename = Path(raw_filename)
         if traces_to_read is not None:


### PR DESCRIPTION
Using `...` means there can be any number
of items in the tuple, but the type is known (string)

![image](https://github.com/nunobrum/PyLTSpice/assets/8218499/e9430824-ca15-48f9-98fb-b06abe4036fd)


See https://docs.python.org/3/library/typing.html#typing.Tuple

> To specify a variable-length tuple of homogeneous type, use literal ellipsis, e.g. Tuple[int, ...]. A plain [Tuple](https://docs.python.org/3/library/typing.html#typing.Tuple) is equivalent to Tuple[Any, ...], and in turn to [tuple](https://docs.python.org/3/library/stdtypes.html#tuple).
