### PR TITLE
Fix time elapsed statistic when running multiple threads

### DIFF
--- a/PyLTSpice/sim/run_task.py
+++ b/PyLTSpice/sim/run_task.py
@@ -40,7 +40,7 @@ END_LINE_TERM = '\n'
 logging.basicConfig(filename='SpiceBatch.log', level=logging.INFO)
 
 if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
-    clock_function = time.process_time
+    clock_function = time.perf_counter
 else:
     clock_function = time.clock
 


### PR DESCRIPTION
Fixes https://github.com/nunobrum/PyLTSpice/issues/101

Now the time elapsed statistic looks correct on my end :) 

![image](https://github.com/nunobrum/PyLTSpice/assets/8218499/0afac98d-6d57-4a93-866b-07ce1a8608df)
