### PR TITLE
Add command line switches to LTSpice netlist call

### DIFF
--- a/PyLTSpice/sim/ltspice_simulator.py
+++ b/PyLTSpice/sim/ltspice_simulator.py
@@ -179,7 +179,7 @@ class LTspice(Simulator):
         circuit_file = Path(circuit_file)
         if sys.platform == 'darwin':
             NotImplementedError("In this platform LTSpice doesn't have netlist generation capabilities")
-        cmd_netlist = cls.spice_exe + ['-netlist'] + [circuit_file.as_posix()]
+        cmd_netlist = cls.spice_exe + ['-netlist'] + [circuit_file.as_posix()] + cmd_line_switches
         # print(f'Creating netlist file from "{circuit_file}"', end='...')
         error = run_function(cmd_netlist)
 


### PR DESCRIPTION
When an `.asc` file is opened for simulation, it is first converted to a netlist through a call to LTSpice with the `-netlist` option. However, if the diagram contains custom symbols that are not located in the default symbol directory an error is thrown. Adding search paths was already possible through the command line switches, but these were not added in the call to create the netlist.

**Example folder structure**
```shell
├── CircuitDiagram.asc
├── SimulateCircuit.py
├── sub
│   ├── CustomOpamp.sub
├── sym
│   ├── CustomOpamp.asy
```

**Simulation**
```python
LTC = PyLTSpice.SimRunner(output_folder='./out')
LTC.add_command_line_switch('-I', 'sub')
LTC.add_command_line_switch('-I', 'sym')

netlist = PyLTSpice.AscEditor('DampedOscillation.asc')
LTC.run(netlist)
LTC.wait_completion()
```
