### PR TITLE
Remove calls to "read_measures()" from documentation.

### DIFF
--- a/PyLTSpice/sim/sim_batch.py
+++ b/PyLTSpice/sim/sim_batch.py
@@ -88,7 +88,6 @@ The RAW file and the LOG file names. Below is an example of a callback function:
         print("Simulation Raw file is %s. The log is %s" % (raw_filename, log_filename)
         # Other code below either using LTSteps.py or raw_read.py
         log_info = LTSpiceLogReader(log_filename)
-        log_info.read_measures()
         rise, measures = log_info.dataset["rise_time"]
 
 The callback function is optional. If  no callback function is given, the thread is terminated just after the

--- a/PyLTSpice/sim/sim_runner.py
+++ b/PyLTSpice/sim/sim_runner.py
@@ -85,7 +85,6 @@ The RAW file and the LOG file names. Below is an example of a callback function:
         print("Simulation Raw file is %s. The log is %s" % (raw_filename, log_filename)
         # Other code below either using LTSteps.py or raw_read.py
         log_info = LTSpiceLogReader(log_filename)
-        log_info.read_measures()
         rise, measures = log_info.dataset["rise_time"]
 
 The callback function is optional. If  no callback function is given, the thread is terminated just after the

--- a/doc/modules/run_simulations.rst
+++ b/doc/modules/run_simulations.rst
@@ -165,7 +165,6 @@ The RAW file and the LOG file names. Below is an example of a callback function.
         print("Simulation Raw file is %s. The log is %s" % (raw_filename, log_filename)
         # Other code below either using LTSteps.py or raw_read.py
         log_info = LTSpiceLogReader(log_filename)
-        log_info.read_measures()
         rise, measures = log_info.dataset["rise_time"]
         return rise, measures
 
@@ -222,7 +221,6 @@ previous code using processes looks like this.
             print("Simulation Raw file is %s. The log is %s" % (raw_filename, log_filename)
             # Other code below either using LTSteps.py or raw_read.py
             log_info = LTSpiceLogReader(log_filename)
-            log_info.read_measures()
             rise, measures = log_info.dataset["rise_time"]
             return rise, measures
 


### PR DESCRIPTION
Remove call to "read_measures()" in documentation, since this method has been removed, per bottom comment of issue #151.