### PR TITLE
Fix TypeError when initializing SpiceEditor

### DIFF
--- a/PyLTSpice/editor/spice_editor.py
+++ b/PyLTSpice/editor/spice_editor.py
@@ -32,7 +32,7 @@ class SpiceEditor(SpiceEditorBase):
         if netlist_file.suffix == ".asc":
             LTspice.create_netlist(netlist_file)
             netlist_file = netlist_file.with_suffix(".net")
-        super().__init__(netlist_file, encoding, create_blank)
+        super().__init__(netlist_file, encoding, create_blank=create_blank)
 
     def run(self, wait_resource: bool = True, callback: Callable[[str, str], Any] = None, timeout: float = 600,
             run_filename: str = None, simulator=None):

--- a/unittests/test_pyltspice.py
+++ b/unittests/test_pyltspice.py
@@ -485,7 +485,12 @@ class test_pyltspice(unittest.TestCase):
                 self.assertAlmostEqual(angle(vout), angle(h), 5,
                                        f"Difference between theoretical value ans simulation at point {point}")
 
-    # 
+    def test_create_blank(self):
+        """SpiceEditor forwards create_blank to the base class without raising"""
+        editor = SpiceEditor("blank.net", create_blank=True)
+        self.assertIsInstance(editor, SpiceEditor)
+
+    #
     # def test_pathlib(self):
     #     """pathlib support"""
     #     import pathlib


### PR DESCRIPTION
Fixes #159.

`SpiceEditor.__init__` passes `create_blank` positionally to the base class, but the spicelib `SpiceEditor` now takes only `netlist_file` and `encoding` positionally (the rest go through `**kwargs`), so any instantiation raises `TypeError: SpiceEditor.__init__() takes from 2 to 3 positional arguments but 4 were given`. Passing it as a keyword (`create_blank=create_blank`) restores construction. Added a regression test that builds a blank editor without LTSpice.